### PR TITLE
Modbus coils do not shift the readout by n%8

### DIFF
--- a/freemodbus/serial_master/modbus_controller/mbc_serial_master.c
+++ b/freemodbus/serial_master/modbus_controller/mbc_serial_master.c
@@ -622,7 +622,7 @@ eMBErrorCode eMBRegDiscreteCBSerialMaster(UCHAR * pucRegBuffer, USHORT usAddress
         iRegBitIndex = (USHORT)(usAddress) % 8; // Get bit index
         while (iNReg > 1)
         {
-            xMBUtilSetBits(pucDiscreteInputBuf++, iRegBitIndex, 8, *pucRegBuffer++);
+            xMBUtilSetBits(pucDiscreteInputBuf++, iRegBitIndex - ((USHORT)(usAddress) % 8), 8, *pucRegBuffer++);
             iNReg--;
         }
         // last discrete
@@ -630,7 +630,7 @@ eMBErrorCode eMBRegDiscreteCBSerialMaster(UCHAR * pucRegBuffer, USHORT usAddress
         // xMBUtilSetBits has bug when ucNBits is zero
         if (usNDiscrete != 0)
         {
-            xMBUtilSetBits(pucDiscreteInputBuf, iRegBitIndex, usNDiscrete, *pucRegBuffer++);
+            xMBUtilSetBits(pucDiscreteInputBuf, iRegBitIndex - ((USHORT)(usAddress) % 8), usNDiscrete, *pucRegBuffer++);
         }
     } else {
         eStatus = MB_ENOREG;

--- a/freemodbus/serial_master/modbus_controller/mbc_serial_master.c
+++ b/freemodbus/serial_master/modbus_controller/mbc_serial_master.c
@@ -567,8 +567,8 @@ eMBErrorCode eMBRegCoilsCBSerialMaster(UCHAR* pucRegBuffer, USHORT usAddress,
         switch (eMode) {
             case MB_REG_WRITE:
                 while (usCoils > 0) {
-                    UCHAR ucResult = xMBUtilGetBits((UCHAR*)pucRegCoilsBuf, iRegIndex, 1);
-                    xMBUtilSetBits(pucRegBuffer, iRegIndex - (usAddress % 8) , 1, ucResult);
+                    UCHAR ucResult = xMBUtilGetBits((UCHAR *)pucRegCoilsBuf, iRegIndex - (usAddress % 8), 1);
+                    xMBUtilSetBits(pucRegBuffer, iRegIndex - (usAddress % 8), 1, ucResult);
                     iRegIndex++;
                     usCoils--;
                 }
@@ -576,7 +576,7 @@ eMBErrorCode eMBRegCoilsCBSerialMaster(UCHAR* pucRegBuffer, USHORT usAddress,
             case MB_REG_READ:
                 while (usCoils > 0) {
                     UCHAR ucResult = xMBUtilGetBits(pucRegBuffer, iRegIndex - (usAddress % 8), 1);
-                    xMBUtilSetBits((uint8_t*)pucRegCoilsBuf, iRegIndex, 1, ucResult);
+                    xMBUtilSetBits((uint8_t *)pucRegCoilsBuf, iRegIndex - (usAddress % 8), 1, ucResult);
                     iRegIndex++;
                     usCoils--;
                 }


### PR DESCRIPTION
Current implementation shifts the reply by a factor of x%8, which does not make any sense.
Double checked against
- modbus docs (examples)
- pymodbus client
- zephyr implementation