### PR TITLE
Bace 10547 load balancing failing tests since esp modbus update

### DIFF
--- a/modbus/mb_controller/tcp/mbc_tcp_master.c
+++ b/modbus/mb_controller/tcp/mbc_tcp_master.c
@@ -177,20 +177,6 @@ static esp_err_t mbc_tcp_master_send_request(void *ctx, mb_param_request_t *requ
         uint8_t mb_command = request->command;
         uint16_t mb_offset = request->reg_start;
         uint16_t mb_size = request->reg_size;
-        uint8_t mb_unit_id = request->unit_id;
-
-	/**
-	 * Override the UID in the address info with the one from the parameter descriptor.
-	 * If it failed to override, log warning for diagnosis and continue to send request.
-	 */
-	mb_uid_info_t *addr_info = mbm_port_tcp_get_slave_info(mbm_controller_iface->mb_base->port_obj,
-            						       mb_slave_addr, MB_SOCK_STATE_UNDEF);					       
-        if (addr_info) {
-            	addr_info->uid = mb_unit_id;
-        } else {
-		ESP_LOGW(TAG, "%p Missing address info for server_idx = %d while applying uid = %d, continuing without override",
-			 mbm_controller_iface, (int)mb_slave_addr, (int)mb_unit_id);
-        }
 
         // Set the buffer for callback function processing of received data
         mbm_opts->reg_buffer_ptr = (uint8_t *)data_ptr;
@@ -487,11 +473,34 @@ static esp_err_t mbc_tcp_master_set_parameter(void *ctx, uint16_t cid, uint8_t *
     error = mbc_tcp_master_set_request(ctx, cid, MB_PARAM_WRITE, &request, &reg_info);
     if ((error == ESP_OK) && (cid == reg_info.cid) && (request.slave_addr != MB_SLAVE_ADDR_PLACEHOLDER)) {
         mb_uid_info_t *addr_info = mbm_port_tcp_get_slave_info(mbm_controller_iface->mb_base->port_obj,
-                                   request.slave_addr, MB_SOCK_STATE_CONNECTED);
+                                   request.slave_addr, MB_SOCK_STATE_UNDEF);
+
+	/**
+	 * Get the address info for the CID.
+	 * I'm not sure why the original `esp-modbus` wanted to continue with the request even if the node is not connected, 
+	 * but I lowered it to undefined, so that we would always get the `addr_info` unless something really strange happened.
+	 * When we have the `addr_info`, we will log it, and then override the UID in the address info with the one from the
+	 * parameter descriptor. If something strange does happen and we don't get the `addr_info`, then we will log an error
+	 * and return.
+	 */
         if (!addr_info) {
             ESP_LOGW(TAG, "Try to send request for cid #%u with uid = %d, node is disconnected.",
                      (unsigned)reg_info.cid, (int)request.slave_addr);
+	    return ESP_ERR_INVALID_STATE;
         }
+	ESP_LOGI(TAG, "%p Found config for cid #%u, server_idx=%d, ip: %s.",
+        	 mbm_controller_iface, (unsigned)reg_info.cid, (int)request.slave_addr, addr_info->ip_addr_str);
+
+	/* Override the UID in the address info with the one from the parameter descriptor */
+	addr_info->uid = request.unit_id;
+	ESP_LOGI(TAG, "%p requests for CID #%u with UID = %d on server_idx = %d (%s)", 
+		 mbm_controller_iface,
+		 (unsigned)reg_info.cid,
+		 (int)request.unit_id,
+		 (int)request.slave_addr,
+		 addr_info->ip_addr_str
+	);
+
         MB_MASTER_ASSERT(xPortGetFreeHeapSize() > (reg_info.mb_size << 1));
         data_ptr = calloc(1, (reg_info.mb_size << 1)); // alloc parameter buffer
         if (!data_ptr) {

--- a/modbus/mb_controller/tcp/mbc_tcp_master.c
+++ b/modbus/mb_controller/tcp/mbc_tcp_master.c
@@ -179,6 +179,19 @@ static esp_err_t mbc_tcp_master_send_request(void *ctx, mb_param_request_t *requ
         uint16_t mb_size = request->reg_size;
         uint8_t mb_unit_id = request->unit_id;
 
+	/**
+	 * Override the UID in the address info with the one from the parameter descriptor.
+	 * If it failed to override, log warning for diagnosis and continue to send request.
+	 */
+	mb_uid_info_t *addr_info = mbm_port_tcp_get_slave_info(mbm_controller_iface->mb_base->port_obj,
+            						       mb_slave_addr, MB_SOCK_STATE_UNDEF);					       
+        if (addr_info) {
+            	addr_info->uid = mb_unit_id;
+        } else {
+		ESP_LOGW(TAG, "%p Missing address info for server_idx = %d while applying uid = %d, continuing without override",
+			 mbm_controller_iface, (int)mb_slave_addr, (int)mb_unit_id);
+        }
+
         // Set the buffer for callback function processing of received data
         mbm_opts->reg_buffer_ptr = (uint8_t *)data_ptr;
         mbm_opts->reg_buffer_size = mb_size;


### PR DESCRIPTION
Description
We had an issue in tests with multiple unit id. It seems that we have had implemented it in the get parameter function but not in the set parameter function. This causes modbus to write to the wrong unit id.
More description of the investigation can be found here:
https://evalan.atlassian.net/browse/BACE-10547?atlOrigin=eyJpIjoiM2Q0ZDQ3MjU0Mzc4NDhlYmJjMjEwMGM0NzRmM2RjZGUiLCJwIjoiaiJ9

We simply add similiar unit id handling from the getter function (https://github.com/bacedev/esp-modbus/pull/4) to the setter.
This seems to fix the issue and modbus writes to proper register with the correct unit id target.

Testing
Component test was run and passed for multi-asset